### PR TITLE
Fix graph visualization and AI explanation display

### DIFF
--- a/src/components/ExplainModal.tsx
+++ b/src/components/ExplainModal.tsx
@@ -36,7 +36,11 @@ export function ExplainModal({ isOpen, onClose, type, objectId, text, title }: E
         throw new Error('Invalid explanation request');
       }
 
-      setExplanation(result.explanation);
+      if (result.note) {
+        setExplanation(result.note);
+      } else if (result.explanation) {
+        setExplanation(result.explanation);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to get explanation');
     } finally {


### PR DESCRIPTION
This commit addresses two issues:

1.  The network graph was not rendering correctly for objects with sparse data, often showing only a single node. This has been fixed by augmenting the graph data on the frontend in `CaseFile.tsx`. If the graph from the API is minimal, the frontend now creates additional nodes and edges based on the event data, providing a richer visualization.

2.  The AI-generated explanation was not being displayed in the modal. This was due to the frontend expecting an `explanations ` field in the API response, while the API was returning a `note` field. The `ExplainModal.tsx` component has been updated to handle both `note` and `explanation` fields, making it more robust.

Additionally, this commit fixes linting errors in the modified files (`CaseFile.tsx` and `NetworkGraph.tsx`), improving code quality and type safety.