### PR TITLE
fix: Handle missing risks and improve explanation modal

### DIFF
--- a/src/components/ExplainModal.tsx
+++ b/src/components/ExplainModal.tsx
@@ -36,10 +36,11 @@ export function ExplainModal({ isOpen, onClose, type, objectId, text, title }: E
         throw new Error('Invalid explanation request');
       }
 
-      if (result.note) {
-        setExplanation(result.note);
-      } else if (result.explanation) {
-        setExplanation(result.explanation);
+      const explanationText = result.note || result.explanation;
+      if (explanationText) {
+        setExplanation(explanationText);
+      } else {
+        setExplanation('No explanation could be generated for this item.');
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to get explanation');

--- a/src/pages/CaseFile.tsx
+++ b/src/pages/CaseFile.tsx
@@ -259,7 +259,7 @@ export default function CaseFile() {
                   <div>
                     <h4 className="font-semibold text-slate-200 mb-2">Risk Factors</h4>
                     <div className="flex flex-wrap gap-2">
-                      {currentCase.risks.map((risk, index) => (
+                      {currentCase.risks && currentCase.risks.map((risk, index) => (
                         <Badge key={index} variant="outline">
                           {risk.code.replace(/_/g, ' ')}
                         </Badge>


### PR DESCRIPTION
This commit addresses feedback from the previous submission.

- In `CaseFile.tsx`, a check is added to ensure `currentCase.risks` exists before mapping over it. This prevents a `TypeError` when the API does not return a `risks` array for an object.

- In `ExplainModal.tsx`, the logic is improved to handle cases where the AI explanation API returns a successful response but no explanation text. The modal now displays a user-friendly message in this scenario instead of appearing blank.