### PR TITLE
feat: Display object image and fix linting issue

### DIFF
--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -31,6 +31,7 @@ export interface ObjectDetail {
   creator: string | null;
   date_display: string | null;
   risk_score: number;
+  image_url: string | null;
 }
 
 export interface Sentence {


### PR DESCRIPTION
This commit introduces the following changes:

- The `CaseFile.tsx` component is updated to display the image of the object in the "Case Summary" card. It uses the `image_url` from the API response and falls back to a placeholder image if the URL is not available.
- The `ObjectDetail` type in `store.ts` is updated to include the `image_url` property.
- A recurring linting issue in `CaseFile.tsx` related to the `useEffect` hook dependencies is fixed by wrapping the `loadCaseFile` function in `useCallback`.