### PR TITLE
feat: Refactor risk filter UI and add score normalization

### DIFF
--- a/src/components/LeadCard.tsx
+++ b/src/components/LeadCard.tsx
@@ -1,8 +1,9 @@
 import { Lead } from '@/lib/store';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
-import { AlertTriangle, Eye, Calendar, User } from 'lucide-react';
+import { AlertTriangle, Eye, User } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { normalizeRisk } from '@/lib/risk-utils';
 
 interface LeadCardProps {
   lead: Lead;
@@ -10,20 +11,18 @@ interface LeadCardProps {
 }
 
 export function LeadCard({ lead, onClick }: LeadCardProps) {
+  const normalizedScore = normalizeRisk(lead.risk_score);
+
   const getRiskColor = (score: number) => {
-    if (score >= 0.7) return 'risk-high';
-    if (score >= 0.3) return 'risk-medium';
+    if (score >= 75) return 'risk-high';
+    if (score >= 50) return 'risk-medium';
     return 'risk-low';
   };
 
   const getRiskLabel = (score: number) => {
-    if (score >= 0.7) return 'High Risk';
-    if (score >= 0.3) return 'Medium Risk';
+    if (score >= 75) return 'High Risk';
+    if (score >= 50) return 'Medium Risk';
     return 'Low Risk';
-  };
-
-  const formatRiskScore = (score: number) => {
-    return Math.round(score * 100);
   };
 
   // Parse comma-separated signals into array
@@ -58,11 +57,11 @@ export function LeadCard({ lead, onClick }: LeadCardProps) {
           <div className="flex flex-col items-end gap-2">
             <div className={cn(
               "h-3 w-3 rounded-full",
-              lead.risk_score >= 0.7 ? "bg-risk-high shadow-glow" : 
-              lead.risk_score >= 0.3 ? "bg-risk-medium" : "bg-risk-low"
+              normalizedScore >= 75 ? "bg-risk-high shadow-glow" :
+              normalizedScore >= 50 ? "bg-risk-medium" : "bg-risk-low"
             )} />
             <span className="text-xs text-slate-400">
-              {formatRiskScore(lead.risk_score)}%
+              {normalizedScore}
             </span>
           </div>
         </div>
@@ -90,11 +89,11 @@ export function LeadCard({ lead, onClick }: LeadCardProps) {
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Badge 
-              variant={lead.risk_score >= 0.7 ? "destructive" : lead.risk_score >= 0.3 ? "default" : "secondary"}
+              variant={normalizedScore >= 75 ? "destructive" : normalizedScore >= 50 ? "default" : "secondary"}
               className="gap-1"
             >
               <AlertTriangle className="h-3 w-3" />
-              {getRiskLabel(lead.risk_score)}
+              {getRiskLabel(normalizedScore)}
             </Badge>
           </div>
           

--- a/src/components/SearchHeader.tsx
+++ b/src/components/SearchHeader.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import logo from '@/assets/provenance-radar-logo.png';
 import { LeadFilters } from '@/lib/store';
 import { Slider } from './ui/slider';
+import { normalizeRisk, denormalizeRisk } from '@/lib/risk-utils';
 
 interface SearchHeaderProps {
   onSearch?: (query: string) => void;
@@ -49,11 +50,15 @@ export function SearchHeader({
   };
 
   const handleMinScoreChange = (value: number[]) => {
+    const normalizedScore = value[0];
+    const rawScore = denormalizeRisk(normalizedScore);
     onFiltersChange({
       ...filters,
-      min_score: value[0],
+      min_score: rawScore,
     });
   };
+
+  const normalizedValue = normalizeRisk(filters.min_score);
 
   return (
     <header className="border-b border-slate-700 bg-gradient-investigation">
@@ -103,20 +108,20 @@ export function SearchHeader({
               Minimum Risk Score
             </label>
             <span className="text-sm text-slate-400">
-              {Math.round((filters.min_score || 0) * 100)}%+
+              {normalizedValue}+
             </span>
           </div>
           <Slider
-            value={[filters.min_score || 0]}
+            value={[normalizedValue]}
             onValueChange={handleMinScoreChange}
-            max={1}
+            max={100}
             min={0}
-            step={0.1}
+            step={1}
             className="w-full"
           />
           <div className="flex justify-between text-xs text-slate-500">
-            <span>Low Risk (0%)</span>
-            <span>High Risk (100%)</span>
+            <span>Low Risk (0)</span>
+            <span>High Risk (100)</span>
           </div>
         </div>
 

--- a/src/lib/risk-utils.ts
+++ b/src/lib/risk-utils.ts
@@ -1,0 +1,43 @@
+/**
+ * Normalizes a raw risk score (e.g., 100-2000) to a user-friendly 0-100 scale
+ * using a logarithmic curve.
+ * @param score The raw risk score.
+ * @returns A normalized score between 0 and 100.
+ */
+export function normalizeRisk(score: number | null | undefined): number {
+  if (typeof score !== 'number' || isNaN(score)) return 0;
+
+  const safeScore = Math.max(score, 1); // Prevent issues with 0 or negative numbers
+  const offset = 100;                    // Shifts the curve to start ramping up around a raw score of 100
+  const scale = 10;                      // Controls the steepness of the curve
+  const maxScore = 100;                  // Cap the output score
+
+  const normalized = Math.log(safeScore + offset) * scale;
+
+  // Round to the nearest integer and ensure it doesn't exceed the max score
+  return Math.min(Math.round(normalized), maxScore);
+}
+
+/**
+ * Converts a normalized 0-100 score back to its approximate raw score.
+ * This is the inverse of the normalizeRisk function.
+ * @param normalizedScore The normalized score (0-100).
+ * @returns The approximate raw risk score.
+ */
+export function denormalizeRisk(normalizedScore: number): number {
+  if (typeof normalizedScore !== 'number' || isNaN(normalizedScore)) return 0;
+
+  const offset = 100;
+  const scale = 10;
+
+  // If the normalized score is at the max, we can't know the true raw score,
+  // but we can return a high number to represent "at least this much".
+  // For filtering, this might not be perfect, but it's a reasonable approximation.
+  if (normalizedScore >= 100) {
+    return 10000; // A high raw score for filters when the slider is at max
+  }
+
+  const rawScore = Math.exp(normalizedScore / scale) - offset;
+
+  return Math.round(rawScore);
+}


### PR DESCRIPTION
This commit introduces two main improvements to the dashboard: a UI refactoring for the filters and a new frontend normalization for risk scores.

UI Refactoring:
- The "Minimum Risk Score" slider has been moved from the collapsible "Filters" panel to be permanently displayed under the main search bar.
- The "Sources" filter and the now-redundant `FilterPanel` component have been completely removed to simplify the interface.

Risk Score Normalization:
- A logarithmic normalization function (`normalizeRisk`) is now applied to the raw risk scores for display purposes, converting them to a more user-friendly 0-100 scale.
- The filter slider now operates on this new 0-100 scale.
- To maintain compatibility with the backend, the selected filter value is converted back to a raw score using an inverse function (`denormalizeRisk`) before being sent to the API.
- The `LeadCard` component has also been updated to display the new normalized score.