### PR TITLE
feat: Refactor filter UI and normalize risk scores

### DIFF
--- a/src/lib/risk-utils.ts
+++ b/src/lib/risk-utils.ts
@@ -1,16 +1,19 @@
 /**
  * Normalizes a raw risk score (e.g., 100-2000) to a user-friendly 0-100 scale
  * using a logarithmic curve.
- * @param score The raw risk score.
+ * @param score The raw risk score, which may be a number or a string.
  * @returns A normalized score between 0 and 100.
  */
-export function normalizeRisk(score: number | null | undefined): number {
-  if (typeof score !== 'number' || isNaN(score)) return 0;
+export function normalizeRisk(score: any): number {
+  // Coerce score to a number. Handles strings, nulls, undefined.
+  const numericScore = parseFloat(score);
 
-  const safeScore = Math.max(score, 1); // Prevent issues with 0 or negative numbers
-  const offset = 100;                    // Shifts the curve to start ramping up around a raw score of 100
-  const scale = 10;                      // Controls the steepness of the curve
-  const maxScore = 100;                  // Cap the output score
+  if (isNaN(numericScore)) return 0;
+
+  const safeScore = Math.max(numericScore, 1); // Prevent issues with 0 or negative numbers
+  const offset = 100;                          // Shifts the curve to start ramping up around a raw score of 100
+  const scale = 10;                            // Controls the steepness of the curve
+  const maxScore = 100;                        // Cap the output score
 
   const normalized = Math.log(safeScore + offset) * scale;
 


### PR DESCRIPTION
This commit introduces two main improvements to the dashboard: a UI refactoring for the filters and a new frontend normalization for risk scores.

UI Refactoring:
- Moves the "Minimum Risk Score" slider from a collapsible panel to be permanently displayed under the main search bar, simplifying the UI.
- Removes the "Sources" filter and the now-redundant `FilterPanel` component.

Risk Score Normalization:
- Implements a logarithmic `normalizeRisk` function to convert raw risk scores into a more user-friendly 0-100 scale for display. This function now correctly handles string-based numbers from the API.
- Updates the filter slider to operate on this new 0-100 scale.
- To maintain backend compatibility, an inverse function (`denormalizeRisk`) converts the selected filter value back to a raw score for API requests.
- Updates the `LeadCard` component to display the new normalized score.